### PR TITLE
v0.130 r1

### DIFF
--- a/data/abilities/shipmanagement/Orbital.txt
+++ b/data/abilities/shipmanagement/Orbital.txt
@@ -1,5 +1,6 @@
 Ability: BuyTurretL
 	Name: Install Laser Turret
+	Description: #ABL_TURRET_LASER_DESC
 	Target: Orbital = Object
 	Icon: LaserTurret
 	Cooldown: 120
@@ -7,6 +8,8 @@ Ability: BuyTurretL
 
 	AddStatusTo(Orbital, LaserTurret)
 	TargetFilterNotStatus(Orbital, LaserTurret)
+	ABEM_hooks::TargetFilterNotType(Orbital, Planet)
+	ABEM_hooks::TargetRequireCommand(Orbital)
 
 
 	ShowMoneyValue(300)
@@ -17,6 +20,7 @@ Ability: BuyTurretL
 	ShareCooldown(BuyTurretM)
 Ability: BuyTurretR
 	Name: Install Railgun Turret
+	Description: #ABL_TURRET_RAIL_DESC
 	Icon: RailTurret
 	Target: Orbital = Object
 
@@ -25,6 +29,8 @@ Ability: BuyTurretR
 
 	AddStatusTo(Orbital, RailgunTurret)
 	TargetFilterNotStatus(Orbital, RailgunTurret)
+	ABEM_hooks::TargetFilterNotType(Orbital, Planet)
+	ABEM_hooks::TargetRequireCommand(Orbital)
 
 
 
@@ -37,6 +43,7 @@ Ability: BuyTurretR
 	TargetFilterAllied(Orbital)
 Ability: BuyTurretM
 	Name: Install Missile Turret
+	Description: #ABL_TURRET_MISSILE_DESC
 	Target: Orbital = Object
 	Icon: MissileTurret
 	Cooldown: 120
@@ -44,6 +51,8 @@ Ability: BuyTurretM
 
 	AddStatusTo(Orbital, MissileTurret)
 	TargetFilterNotStatus(Orbital, MissileTurret)
+	ABEM_hooks::TargetFilterNotType(Orbital, Planet)
+	ABEM_hooks::TargetRequireCommand(Orbital)
 
 	TargetFilterAllied(Orbital)
 	ShareCooldown(BuyTurretL)
@@ -58,11 +67,11 @@ Ability: SpawnOrbital
 	Target: Place = Point
 	Cooldown: 120
 	Energy Cost: 250
-	Name: Place  an  Outpost
+	Name: Construct Outpost
+	Description: #ABL_BUILD_OUTPOST_DESC
 	Range: 100
 	Icon: OrbitalIcons::0
-	TargetFilterInSystem(Place)
 	
 	ShowMoneyValue(300)
 	ConsumeMoney(300)
-	SpawnOrbital(TradeOutpost)
+	SpawnOrbitalAt(Place, TradeOutpost)

--- a/data/effectors/flak.txt
+++ b/data/effectors/flak.txt
@@ -12,7 +12,6 @@ Effector: Flak
 	Value: Pierce = 0.5
 	Value: SupplyCost = 0
 	Value: Radius
-	Value: Hits
 
 	Range: Range
 	Speed: Speed
@@ -45,7 +44,7 @@ Effector: Flak
 
 		Amount = Damage
 		Radius = Radius
-		Hits = Hits
+		Hits = 4
 	Skin: Skin1
 		ImpactGfx: ImpactFlareRailRed
 		TrailCol: ff8888ff, 00000000

--- a/data/statuses/GDF.txt
+++ b/data/statuses/GDF.txt
@@ -8,10 +8,8 @@ Status: GDF
 	// The arguments for ReactorOverload() are, from left to right:
 	// Power damage multiplier - this is the number by which the ship's power output is multiplied when calculating the blast damage.
 	// Power radius multiplier - the number by which the power output is multiplied when calculating the blast radius.
-	// Power target multiplier - the number by which the power output is multiplied when calculating the target count.
 	// Base damage - the amount of damage added to the damage calculated by the abovementioned damage multiplier.
 	// Base radius - the radius added to the radius calculated by the abovementioned radius multiplier.
-	// Base target count - the number added to the target count calculated by the abovementioned target multiplier.
-	ABEM_hooks::ReactorOverloadHook(5, 2, 0.01, 0, 0, 4)
+	ABEM_hooks::ReactorOverloadHook(5, 2, 0, 0)
 	AddFleetEffectiveness(0.10)
 

--- a/data/subsystems/flagships/weapons/FlakCannon.txt
+++ b/data/subsystems/flagships/weapons/FlakCannon.txt
@@ -26,7 +26,6 @@ Subsystem: FlakCannon
 	Description: #S_FLAK_DESC
 
 	FireArc := pi
-	Hits := round(Size/10) + 2
 	Radius := 1.0 + (log(Size) / log(2) * 4.0)
 	Requires:
 		Command = 1
@@ -61,4 +60,3 @@ Subsystem: FlakCannon
 		SupplyCost = SupplyCost * Reload
 		CapOnTarget = 24
 		Radius = Radius
-		Hits = Hits

--- a/locales/english/355873534_abilities.txt
+++ b/locales/english/355873534_abilities.txt
@@ -1,4 +1,4 @@
-﻿STUFF: BLARGH
+STUFF: BLARGH
 ABL_OVERCHARGE_FLEET_DESC: <<
 	Increase the targeted fleet's effectiveness by 40%.
 
@@ -42,14 +42,14 @@ ABL_REVENANT_ENGINE_DESC: <<
 	[b]Having all 4 parts of The Revenant activated at the same time will grant you control over the most powerful warship in the universe.[/b]
 >>
 ABL_INFILTRATE_DESC: <<
-	Uses a high amount of energy to teleport a well-trained operative onto an enemy flagship.
+	Uses a high amount of energy to teleport a well-trained saboteur onto a flagship or orbital, or into a planetary defense center to disrupt its operations and transmit its sensor data back to the empire. Can be used in tandem with the "Infiltrate" influence card.
 
-	Training the operative costs §200k.
+	Training the saboteur and preparing his personal cloaking device costs §200k.
 >>
 ABL_GDF_DESC: <<
 	Orders a flagship to overcharge its primary reactors. Boosts the damage output of the fleet, but the flagship is destroyed in a catastrophic overload.
 
-	Effectiveness boost starts at 10%, increasing by 5% every 5 seconds until the ship explodes 60 seconds after activation. Explosion deals damage equivalent to 5 times the output of the target ship's power generators (Power) to up to 4 (plus 1 for every 100 Power) targets within a radius of 2*Power units. Cannot be used on a fleet that is under the effects of - or recovering from - Rally Cry.
+	Effectiveness boost starts at 10%, increasing by 5% every 5 seconds until the ship explodes 60 seconds after activation. Explosion deals damage equivalent to the square root of 5*Power to all targets within a radius of the square root of 2*Power units. Cannot be used on a fleet that is under the effects of - or recovering from - Rally Cry.
 >>
 ABL_LW_DESC: <<
 	Orders a fleet to redouble its efforts to defeat an enemy. The additional effort is a significant strain on the fleet's personnel and equipment, however, and they will need to recuperate before they can fight again.
@@ -60,4 +60,29 @@ ABL_MEL_DESC: <<
 	Uses special technology on the Admiral's flagship to mask the energy levels of a fleet, making them appear less powerful to an enemy's sensors. The deception must be maintained, though; every 5 minutes, the effect must be applied again.
 
 	Reduces fleet's apparent DPS by 100. Consumes 200 energy. Cannot stack.
+>>
+ABL_COUNTERINTEL_DESC: <<
+	Uses a moderate amount of energy to disrupt the cloaking devices of saboteurs on a friendly flagship, orbital or planet and capture them. Also takes advantage of the empire's intelligence database to uncover and capture infiltrators from other empires aboard flagships.
+
+	The operation costs §250k to perform.
+>>
+ABL_TURRET_LASER_DESC: <<
+	Installs a laser turret onto a target flagship or orbital. The bulk of the turret's power generator prohibits the use of additional laser turrets on the object.
+
+	Shares a cooldown with other turret construction.
+>>
+ABL_TURRET_RAIL_DESC: <<
+	Installs a pair of railgun turrets onto a target flagship or orbital. The bulk of the turrets' ammo fabricators, reloading mechanisms and induction coils prohibits the use of additional railgun turrets on the object.
+
+	Shares a cooldown with other turret construction.
+>>
+ABL_TURRET_MISSILE_DESC: <<
+	Installs a dual missile turret onto a target flagship or orbital. The bulk of the turret's ammo fabricator prohibits the use of additional missile turrets on the object.
+
+	Shares a cooldown with other turret construction.
+>>
+ABL_BUILD_OUTPOST_DESC: <<
+	Uses a moderate amount of energy to immediately fabricate an outpost at a target location.
+
+	Preparing the components required for the project costs §300k.
 >>

--- a/locales/english/355873534_statuses.txt
+++ b/locales/english/355873534_statuses.txt
@@ -1,3 +1,4 @@
+TRASHCAN: Trash.
 STATUS_POWER_CELL_DESC: <<
 	Upgraded in an ancient shipyard.
 
@@ -7,7 +8,7 @@ STATUS_POWER_CELL: Ancient Retrofit
 STATUS_GDF_DESC: <<
 	Overloading its primary reactor.
 
-	Will gain up to 65% effectiveness before exploding, dealing 5*Power damage to up to 4+(Power/100) enemies in a 2*Power radius.
+	Will gain up to 65% effectiveness before exploding, dealing (5*Power)^(1/2) damage to all enemies in a (2*Power)^(1/2) radius.
 >>
 STATUS_LW_DESC: <<
 	Rallied by a nearby Admiral.
@@ -23,4 +24,9 @@ STATUS_MEL_DESC: <<
 	Has had its energy signature masked by an Admiral's flagship.
 
 	Apparent fleet DPS reduced by 100 for 5 minutes, reducing strength. (Does not actually weaken the fleet.) Must be reapplied after expiration.
+>>
+STATUS_ABEMINFILTRATED_DESC: <<
+	Is the victim of a covert insertion by a saboteur. While the saboteur's presence is known to the vessel's crew - or planetary defense coordinators - they lack the equipment and training required to capture him.
+
+	Fleet effectiveness reduced by 10% (also applies to planetary defense fleets). The saboteur frequently transmits data to his superiors, granting vision of the star system.
 >>

--- a/locales/english/355873534_subsystems.txt
+++ b/locales/english/355873534_subsystems.txt
@@ -11,6 +11,16 @@ BEAM_AMPLIFIER_DESC: <<
 
 	[i][color=#aaa]Placing more than one beam amplifier on a weapon will continue to increase its range and burst damage, but will also skyrocket its labor costs.[/color][/i]
 >>
+EXTRA_GUN_DESC: <<
+	Sophisticated ammo feeds, power conduits, capacitors and emitters allow for two turrets' worth of weapons to be mounted on a single turret. While this conserves space and building materials, it is more difficult to assemble and maintain. In effect, beam turrets receive improved emitters which double the amount of energy they can channel, while other weapons receive a second barrel/launcher which is discharged halfway through the reloading process of the first one to maintain a consistent rate of fire.
+
+	[img=Plus;22;#cf00ff]Can be placed on weapon subsystems.[/img]
+	[img=Plus]Halves the reload time of non-beam weapons and doubles the damage of beam weapons, effectively doubling the weapon's damage per second.[/img]
+	[img=Plus]Construction cost is slightly lower than the price of building two separate weapon subsystems of the same firepower. Does not require more power than two separate weapons.[/img]
+	[img=Plus][img=Minus]Does not count as an additional hex group in ship design, as opposed to two separate weapons - and does not increase hex health.[/img][/img]
+	[img=Minus]Somewhat increases labor cost and significantly increases maintenance cost compared to building two separate weapons.[/img]
+	[img=Minus]Only one module per subsystem.[/img]
+>>
 S_SHIELDED_AMGEN_DESC: <<
 	A sustained matter-antimatter annihilation reaction provides continuous power for the ship. This generator comes with a built-in shield generator to protect it, allowing it to operate at full output - though much of it is used by the shield - even in combat.
 

--- a/locales/english/ABEM Local Branch_subsystems.txt
+++ b/locales/english/ABEM Local Branch_subsystems.txt
@@ -91,18 +91,15 @@ S_ROBOTICSHIPYARD_DESC: <<
 	[img=Minus]Requires power and a high amount of Control.[/img]
 >>
 S_SPYMODULE_DESC: <<
-	A covert transporter system capable of sending infiltrators to enemy ships and planets. Grants the Infiltrate ability.
+	A covert transporter system capable of sending infiltrators to enemy ships and planets. Grants the Transport Saboteur and Counterintelligence abilities.
 
-	[i][bbloc=#ABL_INFILTRATE_DESC/][/i]
+	[img=Plus]The only subsystem capable of countering "Infiltrate" cards or enemy Saboteurs.[/img]
 >>
 SYS_ADMIRALBAY_DESC: <<
 	A command center of sufficient quality to coordinate multiple fleets. Ships with this sort of equipment are always commanded by an Admiral.
 
 	[img=Plus]Grants the "Go Down Fighting", "Rally Cry" and "Mask Energy Levels" abilities.[/img]
 	[img=Minus]Gives less Control than a regular bridge and crew.[/img]
-	[img=MenuIcons:3;20]Go Down Fighting: [i][bbloc=#ABL_GDF_DESC/][/i][/img]
-	[img=MenuIcons:3;20]Rally Cry: [i][bbloc=#ABL_LW_DESC/][/i][/img]
-	[img=MenuIcons:3;20]Mask Energy Levels: [i][bbloc=#ABL_MEL_DESC/][/i][/img]
 >>
 	SHIELDGEN_DESC: <<
 	Creates a shield around the vessel, blocking some incoming damage.

--- a/locales/english/ABEM_subsystems.txt
+++ b/locales/english/ABEM_subsystems.txt
@@ -1,7 +1,0 @@
-PLATEARMOR_DESC: <<
-	Heavy, interlocked plates of metal that protect the ship from damage.
-
-	[img=Plus]High [b][color=#80ff80]health[/color][/b].[/img]
-	[img=Plus]Resists and reduces incoming damage.[/img]
-	[img=Minus]Heavy.[/img]
->>

--- a/scripts/definitions/ABEM_hooks.as
+++ b/scripts/definitions/ABEM_hooks.as
@@ -7,7 +7,7 @@ import status_effects;
 import ABEMCombat;
 #section all
 
-class Regeneration: SubsystemEffect {
+class Regeneration : SubsystemEffect {
 	Document doc("Regenerates itself over time.");
 	Argument amount(AT_Decimal, doc="Amount of health to heal per second.");
 	Argument spread(AT_Boolean, "False", doc="If false, regeneration amount is applied to each hex individually. Otherwise, it is spread evenly across all the hexes.");
@@ -40,14 +40,12 @@ class ReactorOverloadHook : StatusHook {
 	Document doc("Handles the power-boosted explosion of a ship. Do not try to use on anything that isn't a ship.");
 	Argument powerdamage(AT_Decimal, "5", doc="Number by which the ship's power output is multiplied when calculating damage.");
 	Argument powerradius(AT_Decimal, "2", doc="Number by which the ship's power output is multiplied when calculating the blast radius.");
-	Argument powerhits(AT_Decimal, "0.01", doc="Number by which the ship's power output is multiplied when calculating the amount of targets hit. Preferably less than 1 - defaults to 0.01.");
 	Argument basedamage(AT_Decimal, "0", doc="Base damage. Added to the result of the power-damage calculation.");
 	Argument baseradius(AT_Decimal, "0", doc="Base radius. Added to the result of the power-radius calculation.");
-	Argument basehits(AT_Decimal, "4", doc="Base hit count. Added to the result of the power-hit calculation.");
 
 #section server
 	void onDestroy(Object& obj, Status@ status, any@ data) override {
-		ReactorOverload(obj, arguments[0].decimal, arguments[1].decimal, arguments[2].decimal, arguments[3].decimal, arguments[4].decimal, arguments[5].decimal);
+		ReactorOverload(obj, arguments[0].decimal, arguments[1].decimal, arguments[2].decimal, arguments[3].decimal);
 	}
 
 #section all

--- a/scripts/server/ABEMCombat.as
+++ b/scripts/server/ABEMCombat.as
@@ -118,15 +118,13 @@ DamageEventStatus ReduceDamagePercentile(DamageEvent& evt, const vec2u& position
 	return DE_Continue;
 }
 
-void ReactorOverload(Object& obj, double PowerAmountMult, double PowerRadiusMult, double PowerHitsMult, double BaseAmount, double BaseRadius, double BaseHits) {
+void ReactorOverload(Object& obj, double PowerAmountMult, double PowerRadiusMult, double BaseAmount, double BaseRadius) {
 	Ship@ ship = cast<Ship>(obj);
 	if(ship !is null) {
 		double power = ship.blueprint.getEfficiencySum(SV_Power);
-		debug();
 		double amount = BaseAmount + sqrt(power * PowerAmountMult);
 		double radius = BaseRadius + sqrt(power * PowerRadiusMult);
-		double hits = BaseHits + sqrt(power * PowerHitsMult);
-		ObjectAreaExplDamage(obj, amount, radius, hits);
+		ObjectAreaExplDamage(obj, amount, radius, 4);
 		obj.destroy();
 	}
 }


### PR DESCRIPTION
- Disallowed placement of turrets on planets
- Allowed placement of Outposts outside star systems via Engineering Bay
- Fixed bug with Engineering Bay's 'Construct Outpost' ability
- Several new localization keys, removed an unneeded locale file.
- Changed Go Down Fighting and Flak Cannon to be more in line with torpedo explosions. Apparently 'Hits' governs the amount of times an individual target gets hit, not the amount of targets the explosion can hit; with that in mind, they're all set to 4 Hits like a torpedo now.
